### PR TITLE
Fix badge in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 # facilityepimath
 
 <!-- badges: start -->
+[![ForeSITE Group](https://github.com/EpiForeSITE/software/blob/e82ed88f75e0fe5c0a1a3b38c2b94509f122019c/docs/assets/foresite-software-badge.svg)](https://github.com/EpiForeSITE)
 <!-- badges: end -->
 
 The goal of facilityepimath is to provide functions to calculate useful quantities for a user-defined differential equation model of infectious disease transmission among individuals in a healthcare facility, including the basic facility reproduction number and model equilibrium. A full description and derivation of the mathematical results implemented in these functions can be found in the following manuscript:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 # facilityepimath
 
 <!-- badges: start -->
+
+[![ForeSITE
+Group](https://github.com/EpiForeSITE/software/blob/e82ed88f75e0fe5c0a1a3b38c2b94509f122019c/docs/assets/foresite-software-badge.svg)](https://github.com/EpiForeSITE)
 <!-- badges: end -->
 
 The goal of facilityepimath is to provide functions to calculate useful


### PR DESCRIPTION
In the original PR for this, I put the badge in the `.md` file instead of in the `.Rmd` file. This corrects that and renders the `.md` properly.